### PR TITLE
added image message template

### DIFF
--- a/messageTemplate.js
+++ b/messageTemplate.js
@@ -55,3 +55,17 @@ exports.singleImagemapMessage = function (typeName)
     }
   }
 }
+
+/**
+ * Componse parameter for Image Message with given arguments
+ * @param {string} url image url with ssl protocol
+ * @param {string} previewUrl image url with ssl protocol for preview, optional
+ * @return {object} object with schema defined as Image Message API parameter
+ */
+exports.imageMessage = function (url, previewUrl) {
+  return {
+    "type": "image",
+    "originalContentUrl": url,
+    "previewImageUrl": previewUrl || url
+  }
+}


### PR DESCRIPTION
Added new template for [image message](https://developers.line.me/ja/reference/messaging-api/#image-message).

It does not require preview image url currently.

Please note that referred url must have https protocol.